### PR TITLE
Fix empty buildflags

### DIFF
--- a/analysis/analysis.go
+++ b/analysis/analysis.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"errors"
 	"fmt"
+
 	"golang.org/x/tools/go/callgraph"
 	"golang.org/x/tools/go/callgraph/cha"
 	"golang.org/x/tools/go/callgraph/rta"
@@ -12,7 +13,6 @@ import (
 	"golang.org/x/tools/go/pointer"
 	"golang.org/x/tools/go/ssa"
 	"golang.org/x/tools/go/ssa/ssautil"
-	"log"
 )
 
 type ProgramAnalysis struct {
@@ -49,7 +49,7 @@ func RunAnalysis(withTests bool, buildFlags []string, pkgPatterns []string) (*Pr
 	}
 	loaded, err := packages.Load(conf, pkgPatterns...)
 	if err != nil {
-		log.Fatalln("failed packages load:", err)
+		return nil, fmt.Errorf("failed packages load: %w", err)
 	}
 	prog, initialPkgs := ssautil.Packages(loaded, 0)
 

--- a/main.go
+++ b/main.go
@@ -53,7 +53,10 @@ func main() {
 		os.Exit(2)
 	}
 
-	buildFlags := strings.Split(*buildFlag, " ")
+	var buildFlags []string
+	if len(*buildFlag) > 0 {
+		buildFlags = strings.Split(*buildFlag, " ")
+	}
 
 	var mode analysis.AnalysisMode
 	switch *modeFlag {


### PR DESCRIPTION
When using CLI If no build flags were passed then underlying command for listing packages will contain empty argument - like `go list "-e" "-json" "-compiled=true" "-test=false" "-export=true" "-deps=true" "-find=false" "" "--" "some/pkg/..."` - note third from the end argument.

This PR excludes passing down empty build argument